### PR TITLE
Support for single deployment/daemonset status

### DIFF
--- a/pkg/olm/deployment_status.go
+++ b/pkg/olm/deployment_status.go
@@ -1,6 +1,7 @@
 package olm
 
 import (
+	"fmt"
 	oappsv1 "github.com/openshift/api/apps/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -38,12 +39,7 @@ func GetDeploymentStatus(dcs []appsv1.Deployment) DeploymentStatus {
 			return dcs[i].Name
 		},
 		requestedReplicasFunc: func(i int) int32 {
-			intPtr := dcs[i].Spec.Replicas
-			if intPtr == nil {
-				return 0
-			} else {
-				return *intPtr
-			}
+			return getInt32(dcs[i].Spec.Replicas)
 		},
 		targetReplicasFunc: func(i int) int32 {
 			return dcs[i].Status.Replicas
@@ -85,6 +81,49 @@ func getDeploymentStatus(obj deployments) DeploymentStatus {
 			starting = append(starting, obj.name(i))
 		} else {
 			ready = append(ready, obj.name(i))
+		}
+	}
+	log.Info("Found deployments with status ", "stopped", stopped, "starting", starting, "ready", ready)
+	return DeploymentStatus{
+		Stopped:  stopped,
+		Starting: starting,
+		Ready:    ready,
+	}
+
+}
+
+func GetSingleDaemonSetStatus(ds appsv1.DaemonSet) DeploymentStatus {
+	return getSingleDeploymentStatus(ds.Name, 1, ds.Status.DesiredNumberScheduled, ds.Status.NumberReady)
+}
+
+func GetSingleDeploymentStatus(dc appsv1.Deployment) DeploymentStatus {
+	return getSingleDeploymentStatus(dc.Name, getInt32(dc.Spec.Replicas), dc.Status.Replicas, dc.Status.ReadyReplicas)
+}
+
+func GetSingleStatefulSetStatus(ss appsv1.StatefulSet) DeploymentStatus {
+	return getSingleDeploymentStatus(ss.Name, getInt32(ss.Spec.Replicas), ss.Status.Replicas, ss.Status.ReadyReplicas)
+}
+
+func getInt32(pointer *int32) int32 {
+	if pointer == nil {
+		return 0
+	} else {
+		return *pointer
+	}
+
+}
+func getSingleDeploymentStatus(name string, requestedCount int32, targetCount int32, readyCount int32) DeploymentStatus {
+	var ready, starting, stopped []string
+	if requestedCount == 0 || targetCount == 0 {
+		stopped = append(stopped, name)
+	} else {
+		for i := int32(0); i < targetCount; i++ {
+			instanceName := fmt.Sprintf("%s-%d", name, i+1)
+			if i < readyCount {
+				ready = append(ready, instanceName)
+			} else {
+				starting = append(starting, instanceName)
+			}
 		}
 	}
 	log.Info("Found deployments with status ", "stopped", stopped, "starting", starting, "ready", ready)

--- a/pkg/olm/deployment_status_test.go
+++ b/pkg/olm/deployment_status_test.go
@@ -170,3 +170,192 @@ func TestDeploymentConfigsStatus(t *testing.T) {
 	assert.Len(t, status.Ready, 1, "Expected one ready deployment")
 	assert.Equal(t, "ReadyDeployment", status.Ready[0])
 }
+
+func TestSingleDaemonSetStatus(t *testing.T) {
+	obj := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ReadyDeployment",
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: 3,
+			NumberReady:            3,
+		},
+	}
+	status := GetSingleDaemonSetStatus(obj)
+	assert.Len(t, status.Stopped, 0, "Expected no stopped deployments")
+	assert.Len(t, status.Starting, 0, "Expected no starting deployments")
+	assert.Len(t, status.Ready, 3, "Expected three ready deployments")
+	assert.Equal(t, "ReadyDeployment-1", status.Ready[0])
+	assert.Equal(t, "ReadyDeployment-2", status.Ready[1])
+	assert.Equal(t, "ReadyDeployment-3", status.Ready[2])
+}
+
+func TestStartingSingleDaemonSetStatus(t *testing.T) {
+	obj := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "StartingDeployment",
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: 3,
+			NumberReady:            1,
+		},
+	}
+	status := GetSingleDaemonSetStatus(obj)
+	assert.Len(t, status.Stopped, 0, "Expected no stopped deployments")
+	assert.Len(t, status.Ready, 1, "Expected one ready deployment")
+	assert.Equal(t, "StartingDeployment-1", status.Ready[0])
+	assert.Len(t, status.Starting, 2, "Expected two starting deployments")
+	assert.Equal(t, "StartingDeployment-2", status.Starting[0])
+	assert.Equal(t, "StartingDeployment-3", status.Starting[1])
+}
+
+func TestStoppedSingleDaemonSetStatus(t *testing.T) {
+	obj := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "StoppedDeployment",
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: 0,
+			NumberReady:            0,
+		},
+	}
+	status := GetSingleDaemonSetStatus(obj)
+	assert.Len(t, status.Stopped, 1, "Expected one stopped deployment")
+	assert.Equal(t, "StoppedDeployment", status.Stopped[0])
+	assert.Len(t, status.Starting, 0, "Expected no starting deployments")
+	assert.Len(t, status.Ready, 0, "Expected no ready deployments")
+}
+
+func TestSingleDeploymentStatus(t *testing.T) {
+	three := int32(3)
+	obj := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ReadyDeployment",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &three,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:      3,
+			ReadyReplicas: 3,
+		},
+	}
+	status := GetSingleDeploymentStatus(obj)
+	assert.Len(t, status.Stopped, 0, "Expected no stopped deployments")
+	assert.Len(t, status.Starting, 0, "Expected no starting deployments")
+	assert.Len(t, status.Ready, 3, "Expected three ready deployments")
+	assert.Equal(t, "ReadyDeployment-1", status.Ready[0])
+	assert.Equal(t, "ReadyDeployment-2", status.Ready[1])
+	assert.Equal(t, "ReadyDeployment-3", status.Ready[2])
+}
+
+func TestStartingSingleDeploymentStatus(t *testing.T) {
+	three := int32(3)
+	obj := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "StartingDeployment",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &three,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:      3,
+			ReadyReplicas: 1,
+		},
+	}
+	status := GetSingleDeploymentStatus(obj)
+	assert.Len(t, status.Stopped, 0, "Expected no stopped deployments")
+	assert.Len(t, status.Ready, 1, "Expected one ready deployment")
+	assert.Equal(t, "StartingDeployment-1", status.Ready[0])
+	assert.Len(t, status.Starting, 2, "Expected two starting deployments")
+	assert.Equal(t, "StartingDeployment-2", status.Starting[0])
+	assert.Equal(t, "StartingDeployment-3", status.Starting[1])
+}
+
+func TestStoppedSingleDeploymentStatus(t *testing.T) {
+	zero := int32(0)
+	obj := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "StoppedDeployment",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &zero,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:      0,
+			ReadyReplicas: 0,
+		},
+	}
+	status := GetSingleDeploymentStatus(obj)
+	assert.Len(t, status.Stopped, 1, "Expected one stopped deployment")
+	assert.Equal(t, "StoppedDeployment", status.Stopped[0])
+	assert.Len(t, status.Starting, 0, "Expected no starting deployments")
+	assert.Len(t, status.Ready, 0, "Expected no ready deployments")
+}
+
+func TestSingleStatefulSetStatus(t *testing.T) {
+	three := int32(3)
+	obj := appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ReadyDeployment",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &three,
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:      3,
+			ReadyReplicas: 3,
+		},
+	}
+	status := GetSingleStatefulSetStatus(obj)
+	assert.Len(t, status.Stopped, 0, "Expected no stopped deployments")
+	assert.Len(t, status.Starting, 0, "Expected no starting deployments")
+	assert.Len(t, status.Ready, 3, "Expected three ready deployments")
+	assert.Equal(t, "ReadyDeployment-1", status.Ready[0])
+	assert.Equal(t, "ReadyDeployment-2", status.Ready[1])
+	assert.Equal(t, "ReadyDeployment-3", status.Ready[2])
+}
+
+func TestStartingSingleStatefulSetStatus(t *testing.T) {
+	three := int32(3)
+	obj := appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "StartingDeployment",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &three,
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:      3,
+			ReadyReplicas: 1,
+		},
+	}
+	status := GetSingleStatefulSetStatus(obj)
+	assert.Len(t, status.Stopped, 0, "Expected no stopped deployments")
+	assert.Len(t, status.Ready, 1, "Expected one ready deployment")
+	assert.Equal(t, "StartingDeployment-1", status.Ready[0])
+	assert.Len(t, status.Starting, 2, "Expected two starting deployments")
+	assert.Equal(t, "StartingDeployment-2", status.Starting[0])
+	assert.Equal(t, "StartingDeployment-3", status.Starting[1])
+}
+
+func TestStoppedSingleStatefulSetStatus(t *testing.T) {
+	zero := int32(0)
+	obj := appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "StoppedDeployment",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &zero,
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:      0,
+			ReadyReplicas: 0,
+		},
+	}
+	status := GetSingleStatefulSetStatus(obj)
+	assert.Len(t, status.Stopped, 1, "Expected one stopped deployment")
+	assert.Equal(t, "StoppedDeployment", status.Stopped[0])
+	assert.Len(t, status.Starting, 0, "Expected no starting deployments")
+	assert.Len(t, status.Ready, 0, "Expected no ready deployments")
+}


### PR DESCRIPTION
Added support for podStatuses where there is a single deployment or daemon set

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>