### PR TITLE
abstract OCPVersion fetch to own func call [sec perms issue]

### DIFF
--- a/pkg/platform/platform_info.go
+++ b/pkg/platform/platform_info.go
@@ -47,6 +47,25 @@ func (info PlatformInfo) IsKubernetes() bool {
 	return info.Name == Kubernetes
 }
 
+func (info *PlatformInfo) ApproximateOpenShiftVersion() {
+
+	if info.K8SVersion == "" || info.Name == Kubernetes {
+		return
+	}
+	switch info.K8SVersion {
+	case "1.10+":
+		info.OCPVersion = "3.10"
+	case "1.11+":
+		info.OCPVersion = "3.11"
+	case "1.13+":
+		info.OCPVersion = "4.1"
+	default:
+		log.Info("unable to version-match OCP to K8S version " + info.K8SVersion)
+		info.OCPVersion = ""
+		return
+	}
+}
+
 func (info PlatformInfo) String() string {
 	return "PlatformInfo [" +
 		"Name: " + fmt.Sprintf("%v", info.Name) +

--- a/pkg/platform/platform_info_test.go
+++ b/pkg/platform/platform_info_test.go
@@ -46,6 +46,56 @@ func TestK8SVersionHelpers(t *testing.T) {
 	}
 }
 
+func TestPlatformInfo_ApproximateOpenShiftVersion(t *testing.T) {
+
+	cases := []struct {
+		label              string
+		info               PlatformInfo
+		expectedOCPVersion string
+	}{
+		{
+			label:              "case 1",
+			info:               PlatformInfo{},
+			expectedOCPVersion: "",
+		},
+		{
+			label:              "case 2",
+			info:               PlatformInfo{Name: Kubernetes},
+			expectedOCPVersion: "",
+		},
+		{
+			label:              "case 3",
+			info:               PlatformInfo{Name: OpenShift, K8SVersion: "1.10+"},
+			expectedOCPVersion: "3.10",
+		},
+		{
+			label:              "case 4",
+			info:               PlatformInfo{Name: OpenShift, K8SVersion: "1.11+"},
+			expectedOCPVersion: "3.11",
+		},
+		{
+			label:              "case 5",
+			info:               PlatformInfo{Name: OpenShift, K8SVersion: "1.13+"},
+			expectedOCPVersion: "4.1",
+		},
+		{
+			label:              "case 6",
+			info:               PlatformInfo{Name: OpenShift, K8SVersion: "1.99"},
+			expectedOCPVersion: "",
+		},
+		{
+			label:              "case 7",
+			info:               PlatformInfo{Name: OpenShift},
+			expectedOCPVersion: "",
+		},
+	}
+
+	for _, v := range cases {
+		v.info.ApproximateOpenShiftVersion()
+		assert.Equal(t, v.expectedOCPVersion, v.info.OCPVersion, v.label+": expected OCP version to match")
+	}
+}
+
 func TestPlatformInfo_String(t *testing.T) {
 
 	info := PlatformInfo{Name: OpenShift, OCPVersion: "1.1.1+", K8SVersion: "456", OS: "foo/bar"}

--- a/pkg/platform/platform_versioner_test.go
+++ b/pkg/platform/platform_versioner_test.go
@@ -169,12 +169,11 @@ func TestK8SBasedPlatformVersioner_GetPlatformInfo(t *testing.T) {
 			expectedErr:  false,
 		},
 		{
-			label: "case 4", // trigger error in OpenAPISchema, info should now be OCP with K8S major/minor
+			label: "case 4", // let K8S version start with "1.10+", info should now reflect OCP approximation
 			discoverer: FakeDiscoverer{
-				OpenAPISchemaError: fakeErr,
 				serverInfo: &version.Info{
 					Major: "1",
-					Minor: "2",
+					Minor: "10+",
 				},
 				groupList: &v1.APIGroupList{
 					TypeMeta: v1.TypeMeta{},
@@ -186,15 +185,15 @@ func TestK8SBasedPlatformVersioner_GetPlatformInfo(t *testing.T) {
 				},
 			},
 			config:       &rest.Config{},
-			expectedInfo: PlatformInfo{Name: OpenShift, K8SVersion: "1.2"},
-			expectedErr:  true,
+			expectedInfo: PlatformInfo{Name: OpenShift, K8SVersion: "1.10+", OCPVersion: "3.10"},
+			expectedErr:  false,
 		},
 		{
-			label: "case 5", // trigger no error, let OCP version start with "3.1", info should now reflect this
+			label: "case 5", // let K8S version start with "1.11+", info should now reflect OCP approximation
 			discoverer: FakeDiscoverer{
 				serverInfo: &version.Info{
 					Major: "1",
-					Minor: "2",
+					Minor: "11+",
 				},
 				groupList: &v1.APIGroupList{
 					TypeMeta: v1.TypeMeta{},
@@ -204,14 +203,29 @@ func TestK8SBasedPlatformVersioner_GetPlatformInfo(t *testing.T) {
 						},
 					},
 				},
-				doc: &openapi_v2.Document{
-					Info: &openapi_v2.Info{
-						Version: "v3.11.42",
+			},
+			config:       &rest.Config{},
+			expectedInfo: PlatformInfo{Name: OpenShift, K8SVersion: "1.11+", OCPVersion: "3.11"},
+			expectedErr:  false,
+		},
+		{
+			label: "case 6", // let K8S version start with "1.13+", info should now reflect OCP approximation
+			discoverer: FakeDiscoverer{
+				serverInfo: &version.Info{
+					Major: "1",
+					Minor: "13+",
+				},
+				groupList: &v1.APIGroupList{
+					TypeMeta: v1.TypeMeta{},
+					Groups: []v1.APIGroup{
+						{
+							Name: "route.openshift.io",
+						},
 					},
 				},
 			},
 			config:       &rest.Config{},
-			expectedInfo: PlatformInfo{Name: OpenShift, K8SVersion: "1.2", OCPVersion: "v3.11.42"},
+			expectedInfo: PlatformInfo{Name: OpenShift, K8SVersion: "1.13+", OCPVersion: "4.1"},
 			expectedErr:  false,
 		},
 	}

--- a/pkg/utils/openshift/utils.go
+++ b/pkg/utils/openshift/utils.go
@@ -15,10 +15,23 @@ func IsOpenShift(cfg *rest.Config) (bool, error) {
 
 /*
 GetPlatformInfo examines the Kubernetes-based environment and determines the running platform, version, & OS.
+Returned PlatformInfo.OCPVersion is derived from underlying PlatformInfo.K8SVersion.
 Accepts <nil> or instantiated 'cfg' rest config parameter.
 
-Result: PlatformInfo{ Name: OpenShift, OCPVersion: 4.1.0, K8SVersion: 1.13+, OS: linux/amd64 }
+Result: PlatformInfo{ Name: OpenShift, OCPVersion: 4.1, K8SVersion: 1.13+, OS: linux/amd64 }
 */
 func GetPlatformInfo(cfg *rest.Config) (platform.PlatformInfo, error) {
 	return platform.K8SBasedPlatformVersioner{}.GetPlatformInfo(nil, cfg)
+}
+
+/*
+LookupOpenShiftVersion refines PlatformInfo.OCPVersion info based on API calls, rather than deriving from K8SVersion.
+*** NOTE: OCP 4.1+ requires elevated user permissions, see PlatformVersioner for details
+Accepts <nil> or instantiated 'cfg' rest config parameter.
+Accepts prepopulated or empty PlatformInfo{}
+
+Result: PlatformInfo{ Name: OpenShift, OCPVersion: 4.1.2, K8SVersion: 1.13+, OS: linux/amd64 }
+*/
+func LookupOpenShiftVersion(cfg *rest.Config, info platform.PlatformInfo) (platform.PlatformInfo, error) {
+	return platform.K8SBasedPlatformVersioner{}.LookupOpenShiftVersion(nil, cfg, info)
 }


### PR DESCRIPTION
IsOpenShift (GetPlatformInfo) will now approximate OCPVersion based on K8S platform version that's always available without making additional API call for OCP4+ that requires elevated user permissions. If coder wishes to refine/verify the OCP version further if/once permissions are in place, the new method added (utils.LookupOpenShiftVersion) can do so.