### PR TITLE
Further enhancements to updates

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -487,7 +487,7 @@
   revision = "1d1b8b084b3057162613acc6cba8af4e30dc2ec4"
 
 [[projects]]
-  digest = "1:78f6a824d205c6cb0d011cce241407646b773cb57ee27e8c7e027753b4111075"
+  digest = "1:81683bf6c1b4aecdc3ff5691254983eeab14705d3bca1cb2db10656d4ff347ce"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -515,15 +515,18 @@
     "pkg/util/framer",
     "pkg/util/intstr",
     "pkg/util/json",
+    "pkg/util/mergepatch",
     "pkg/util/naming",
     "pkg/util/net",
     "pkg/util/runtime",
     "pkg/util/sets",
+    "pkg/util/strategicpatch",
     "pkg/util/validation",
     "pkg/util/validation/field",
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
+    "third_party/forked/golang/json",
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
@@ -531,7 +534,7 @@
   version = "kubernetes-1.14.1"
 
 [[projects]]
-  digest = "1:72b7cb4419164da285783acc5bd4a306df21bd05a05fe59c98e1139cb196d5bb"
+  digest = "1:c460475440532e591371b7171acffd908aa16a7a75c82ab6b1d631bcd3c3120d"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -545,6 +548,7 @@
     "rest",
     "rest/watch",
     "restmapper",
+    "testing",
     "tools/auth",
     "tools/clientcmd",
     "tools/clientcmd/api",
@@ -572,6 +576,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:22abb5d4204ab1a0dcc9cda64906a31c43965ff5159e8b9f766c9d2a162dbed5"
+  name = "k8s.io/kube-openapi"
+  packages = ["pkg/util/proto"]
+  pruneopts = "UT"
+  revision = "743ec37842bffe49dd4221d9026f30fb1d5adbc4"
+
+[[projects]]
+  branch = "master"
   digest = "1:8b40227d4bf8b431fdab4f9026e6e346f00ac3be5662af367a183f78c57660b3"
   name = "k8s.io/utils"
   packages = ["integer"]
@@ -579,14 +591,16 @@
   revision = "c55fbcfc754a5b2ec2fbae8fb9dcac36bdba6a12"
 
 [[projects]]
-  digest = "1:f281493889e2ca62ab6fed2ae3c7a277a1143ff2f944f519ff5126719e1f3d08"
+  digest = "1:9324f3733f2ac874864c360a030b335cb0786dd91a2b36156f146da2b2dad140"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/client",
     "pkg/client/apiutil",
     "pkg/client/config",
+    "pkg/client/fake",
     "pkg/controller/controllerutil",
     "pkg/internal/log",
+    "pkg/internal/objectutil",
     "pkg/log",
     "pkg/log/zap",
     "pkg/runtime/log",
@@ -621,11 +635,13 @@
     "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/version",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/rest",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
+    "sigs.k8s.io/controller-runtime/pkg/client/fake",
     "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil",
     "sigs.k8s.io/controller-runtime/pkg/runtime/log",
   ]

--- a/pkg/resource/compare/defaults_test.go
+++ b/pkg/resource/compare/defaults_test.go
@@ -56,3 +56,12 @@ func TestCompareDeploymentConfigs(t *testing.T) {
 	assert.True(t, deepEquals(&dcs[0], &dcs[1]), "Expected resources to be deemed equal")
 	assert.True(t, equalDeploymentConfigs(&dcs[0], &dcs[1]), "Expected resources to be deemed equal based on DC comparator")
 }
+
+func TestCompareEmptyAnnotations(t *testing.T) {
+	routes := utils.GetRoutes(2)
+	routes[1].Name = routes[0].Name
+	routes[0].Annotations = make(map[string]string)
+	routes[0].Annotations["openshift.io/host.generated"] = "true"
+	routes[1].Annotations = nil
+	assert.True(t, equalRoutes(&routes[0], &routes[1]), "Routes should be considered equal")
+}

--- a/pkg/resource/write/hooks/update_hooks.go
+++ b/pkg/resource/write/hooks/update_hooks.go
@@ -1,0 +1,50 @@
+package hooks
+
+import (
+	"github.com/RHsyseng/operator-utils/pkg/resource"
+	corev1 "k8s.io/api/core/v1"
+	"reflect"
+)
+
+type hookFunc = func(existing resource.KubernetesResource, requested resource.KubernetesResource) error
+
+type UpdateHookMap struct {
+	DefaultHook hookFunc
+	HookMap     map[reflect.Type]hookFunc
+}
+
+func DefaultUpdateHooks() *UpdateHookMap {
+	hookMap := make(map[reflect.Type]func(existing resource.KubernetesResource, requested resource.KubernetesResource) error)
+	hookMap[reflect.TypeOf(corev1.Service{})] = serviceHook
+	return &UpdateHookMap{
+		DefaultHook: defaultHook,
+		HookMap:     hookMap,
+	}
+}
+
+func (this *UpdateHookMap) Trigger(existing resource.KubernetesResource, requested resource.KubernetesResource) error {
+	function := this.HookMap[reflect.ValueOf(existing).Elem().Type()]
+	if function == nil {
+		function = this.DefaultHook
+	}
+	return function(existing, requested)
+}
+
+func defaultHook(existing resource.KubernetesResource, requested resource.KubernetesResource) error {
+	requested.SetResourceVersion(existing.GetResourceVersion())
+	requested.GetObjectKind().SetGroupVersionKind(existing.GetObjectKind().GroupVersionKind())
+	return nil
+}
+
+func serviceHook(existing resource.KubernetesResource, requested resource.KubernetesResource) error {
+	existingService := existing.(*corev1.Service)
+	requestedService := requested.(*corev1.Service)
+	if requestedService.Spec.ClusterIP == "" {
+		requestedService.Spec.ClusterIP = existingService.Spec.ClusterIP
+	}
+	err := defaultHook(existing, requested)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/resource/write/writer_test.go
+++ b/pkg/resource/write/writer_test.go
@@ -1,9 +1,14 @@
 package write
 
 import (
+	"context"
+	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 )
 
@@ -19,4 +24,75 @@ func TestFluentAPI(t *testing.T) {
 	controler := New().WithOwnerReferences(v1.OwnerReference{})
 	assert.NotNil(t, controler.ownerRefs, "Expect ownerRefs to be set")
 	assert.Nil(t, controler.ownerController, "Do not expect ownerController to be set")
+}
+
+func TestCreateService(t *testing.T) {
+	scheme := getScheme(t)
+	client := fake.NewFakeClientWithScheme(scheme)
+	requestedService := corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "service1",
+			Namespace: "namespace",
+		},
+		Spec: corev1.ServiceSpec{
+			SessionAffinity: corev1.ServiceAffinityClientIP,
+		},
+	}
+	requestedService.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
+	added, err := New().AddResources(scheme, client, []resource.KubernetesResource{&requestedService})
+	assert.Nil(t, err, "Expect no errors creating a simple object")
+	assert.True(t, added, "Object should be added")
+
+	existingService := corev1.Service{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: "service1", Namespace: "namespace"}, &existingService)
+	assert.Nil(t, err, "Expect no errors loading existing object")
+	assert.Equal(t, requestedService, existingService)
+}
+
+func TestUpdateService(t *testing.T) {
+	scheme := getScheme(t)
+	clusterIP := "1.2.3.4"
+	client := fake.NewFakeClientWithScheme(scheme)
+	requestedService := corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "service1",
+			Namespace: "namespace",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP:       clusterIP,
+			SessionAffinity: corev1.ServiceAffinityClientIP,
+		},
+	}
+	requestedService.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
+	added, err := New().AddResources(scheme, client, []resource.KubernetesResource{&requestedService})
+	assert.Nil(t, err, "Expect no errors creating a simple object")
+	assert.True(t, added, "Object should be added")
+
+	updatedService := corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "service1",
+			Namespace: "namespace",
+		},
+		Spec: corev1.ServiceSpec{
+			SessionAffinity: corev1.ServiceAffinityNone,
+		},
+	}
+	updatedService.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
+	updated, err := New().UpdateResources([]resource.KubernetesResource{&requestedService}, scheme, client, []resource.KubernetesResource{&updatedService})
+	assert.Nil(t, err, "Expect no errors updating object")
+	assert.True(t, updated, "Object should be updated")
+
+	existingService := corev1.Service{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: "service1", Namespace: "namespace"}, &existingService)
+	assert.Nil(t, err, "Expect no errors loading existing object")
+	//Update call should set the existing ClusterIP on the object before writing it:
+	updatedService.Spec.ClusterIP = clusterIP
+	assert.Equal(t, updatedService, existingService, "Expected Cluster IP to be set on the updating object")
+}
+
+func getScheme(t *testing.T) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	err := corev1.SchemeBuilder.AddToScheme(scheme)
+	assert.Nil(t, err, "Expect no errors building scheme")
+	return scheme
 }


### PR DESCRIPTION
- Added update hooks to allow behavior specific to the object being updated, for example a Service needs its clusterIP set as is on the cluster
- Increased logging when resources are detected to be different
- Avoid an extra reconciliation cycle because of empty and nil annotations/labels maps being reported as unequal

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>