### PR TITLE
Further DC comparison logic

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -257,10 +257,11 @@
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:cc18cf101cc07b176fcf6d04137d267afbd9b88c9c3dbe0dde3ddae072992a6e"
+  digest = "1:cd1052701c9640c2d3d594ab729243a2a03315a970586c060861b28f98922909"
   name = "github.com/openshift/api"
   packages = [
     "apps/v1",
+    "build/v1",
     "route/v1",
   ]
   pruneopts = "UT"
@@ -627,6 +628,7 @@
     "github.com/go-openapi/validate",
     "github.com/googleapis/gnostic/OpenAPIv2",
     "github.com/openshift/api/apps/v1",
+    "github.com/openshift/api/build/v1",
     "github.com/openshift/api/route/v1",
     "github.com/pkg/errors",
     "github.com/stretchr/testify/assert",

--- a/pkg/resource/compare/defaults.go
+++ b/pkg/resource/compare/defaults.go
@@ -61,6 +61,7 @@ func equalDeploymentConfigs(deployed resource.KubernetesResource, requested reso
 
 	//Removed generated fields from deployed version, when not specified in requested item
 	dc1 = dc1.DeepCopy()
+	triggerBasedImage := make(map[string]bool)
 	if dc2.Spec.Strategy.RecreateParams == nil {
 		dc1.Spec.Strategy.RecreateParams = nil
 	}
@@ -80,6 +81,19 @@ func equalDeploymentConfigs(deployed resource.KubernetesResource, requested reso
 	}
 	if dc2.Spec.RevisionHistoryLimit == nil {
 		dc1.Spec.RevisionHistoryLimit = nil
+	}
+	for i := range dc1.Spec.Triggers {
+		if len(dc2.Spec.Triggers) <= i {
+			return false
+		}
+		if dc1.Spec.Triggers[i].ImageChangeParams != nil && dc2.Spec.Triggers[i].ImageChangeParams != nil {
+			if dc2.Spec.Triggers[i].ImageChangeParams.LastTriggeredImage == "" {
+				dc1.Spec.Triggers[i].ImageChangeParams.LastTriggeredImage = ""
+			}
+			for _, containerName := range dc2.Spec.Triggers[i].ImageChangeParams.ContainerNames {
+				triggerBasedImage[containerName] = true
+			}
+		}
 	}
 	if dc1.Spec.Template != nil && dc2.Spec.Template != nil {
 		for i := range dc1.Spec.Template.Spec.Volumes {
@@ -107,48 +121,10 @@ func equalDeploymentConfigs(deployed resource.KubernetesResource, requested reso
 		if dc2.Spec.Template.Spec.SchedulerName == "" {
 			dc1.Spec.Template.Spec.SchedulerName = ""
 		}
-		for i := range dc1.Spec.Template.Spec.Containers {
-			if len(dc2.Spec.Template.Spec.Containers) <= i {
-				return false
-			}
-			probe1 := dc1.Spec.Template.Spec.Containers[i].LivenessProbe
-			probe2 := dc2.Spec.Template.Spec.Containers[i].LivenessProbe
-			if probe1 != nil && probe2 != nil {
-				if probe2.FailureThreshold == 0 {
-					probe1.FailureThreshold = probe2.FailureThreshold
-				}
-				if probe2.SuccessThreshold == 0 {
-					probe1.SuccessThreshold = probe2.SuccessThreshold
-				}
-			}
-			probe1 = dc1.Spec.Template.Spec.Containers[i].ReadinessProbe
-			probe2 = dc2.Spec.Template.Spec.Containers[i].ReadinessProbe
-			if probe1 != nil && probe2 != nil {
-				if probe2.FailureThreshold == 0 {
-					probe1.FailureThreshold = probe2.FailureThreshold
-				}
-				if probe2.SuccessThreshold == 0 {
-					probe1.SuccessThreshold = probe2.SuccessThreshold
-				}
-			}
-			if dc2.Spec.Template.Spec.Containers[i].TerminationMessagePath == "" {
-				dc1.Spec.Template.Spec.Containers[i].TerminationMessagePath = ""
-			}
-			if dc2.Spec.Template.Spec.Containers[i].TerminationMessagePolicy == "" {
-				dc1.Spec.Template.Spec.Containers[i].TerminationMessagePolicy = ""
-			}
-			for j := range dc1.Spec.Template.Spec.Containers[i].Env {
-				if len(dc2.Spec.Template.Spec.Containers[i].Env) <= j {
-					return false
-				}
-				valueFrom := dc2.Spec.Template.Spec.Containers[i].Env[j].ValueFrom
-				if valueFrom != nil && valueFrom.FieldRef != nil && valueFrom.FieldRef.APIVersion == "" {
-					valueFrom1 := dc1.Spec.Template.Spec.Containers[i].Env[j].ValueFrom
-					if valueFrom1 != nil && valueFrom1.FieldRef != nil {
-						valueFrom1.FieldRef.APIVersion = ""
-					}
-				}
-			}
+		ignoreGenerateContainerValues(dc1.Spec.Template.Spec.Containers, dc2.Spec.Template.Spec.Containers, triggerBasedImage)
+		ignoreGenerateContainerValues(dc1.Spec.Template.Spec.InitContainers, dc2.Spec.Template.Spec.InitContainers, triggerBasedImage)
+		if dc2.Spec.Template.Spec.TerminationGracePeriodSeconds == nil {
+			dc1.Spec.Template.Spec.TerminationGracePeriodSeconds = nil
 		}
 	}
 	ignoreEmptyMaps(dc1, dc2)
@@ -164,6 +140,63 @@ func equalDeploymentConfigs(deployed resource.KubernetesResource, requested reso
 		logger.Info("Resources are not equal", "deployed", deployed, "requested", requested)
 	}
 	return equal
+}
+
+func ignoreGenerateContainerValues(containers1 []corev1.Container, containers2 []corev1.Container, triggerBasedImage map[string]bool) {
+	for i := range containers1 {
+		if len(containers2) <= i {
+			return
+		}
+		probe1 := containers1[i].LivenessProbe
+		probe2 := containers2[i].LivenessProbe
+		if probe1 != nil && probe2 != nil {
+			if probe2.FailureThreshold == 0 {
+				probe1.FailureThreshold = probe2.FailureThreshold
+			}
+			if probe2.SuccessThreshold == 0 {
+				probe1.SuccessThreshold = probe2.SuccessThreshold
+			}
+			if probe2.PeriodSeconds == 0 {
+				probe1.PeriodSeconds = probe2.PeriodSeconds
+			}
+		}
+		probe1 = containers1[i].ReadinessProbe
+		probe2 = containers2[i].ReadinessProbe
+		if probe1 != nil && probe2 != nil {
+			if probe2.FailureThreshold == 0 {
+				probe1.FailureThreshold = probe2.FailureThreshold
+			}
+			if probe2.SuccessThreshold == 0 {
+				probe1.SuccessThreshold = probe2.SuccessThreshold
+			}
+			if probe2.PeriodSeconds == 0 {
+				probe1.PeriodSeconds = probe2.PeriodSeconds
+			}
+		}
+		if containers2[i].TerminationMessagePath == "" {
+			containers1[i].TerminationMessagePath = ""
+		}
+		if containers2[i].TerminationMessagePolicy == "" {
+			containers1[i].TerminationMessagePolicy = ""
+		}
+		for j := range containers1[i].Env {
+			if len(containers2[i].Env) <= j {
+				return
+			}
+			valueFrom := containers2[i].Env[j].ValueFrom
+			if valueFrom != nil && valueFrom.FieldRef != nil && valueFrom.FieldRef.APIVersion == "" {
+				valueFrom1 := containers1[i].Env[j].ValueFrom
+				if valueFrom1 != nil && valueFrom1.FieldRef != nil {
+					valueFrom1.FieldRef.APIVersion = ""
+				}
+			}
+		}
+		if triggerBasedImage[containers1[i].Name] {
+			//Image is being derived from the ImageChange trigger, so this image field is auto-generated after deployment
+			containers1[i].Image = containers2[i].Image
+		}
+	}
+
 }
 
 func equalServices(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {

--- a/pkg/resource/compare/defaults_test.go
+++ b/pkg/resource/compare/defaults_test.go
@@ -3,6 +3,7 @@ package compare
 import (
 	utils "github.com/RHsyseng/operator-utils/pkg/resource/test"
 	oappsv1 "github.com/openshift/api/apps/v1"
+	obuildv1 "github.com/openshift/api/build/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -112,8 +113,8 @@ func TestCompareDeploymentConfigImageChange(t *testing.T) {
 	}
 	dcs[0].Spec.Template.Spec.Containers = []corev1.Container{
 		{
-			Name:"container1",
-			Image:"some generated value",
+			Name:  "container1",
+			Image: "some generated value",
 		},
 	}
 	dcs[1].Spec.Triggers = []oappsv1.DeploymentTriggerPolicy{
@@ -134,9 +135,32 @@ func TestCompareDeploymentConfigImageChange(t *testing.T) {
 	}
 	dcs[1].Spec.Template.Spec.Containers = []corev1.Container{
 		{
-			Name:"container1",
-			Image:"image",
+			Name:  "container1",
+			Image: "image",
 		},
 	}
 	assert.True(t, equalDeploymentConfigs(&dcs[0], &dcs[1]), "Expected resources to be deemed equal based on DC comparator")
+}
+
+func TestCompareBuildConfigWebHooks(t *testing.T) {
+	bcs := utils.GetBuildConfigs(2)
+	bcs[1].Name = bcs[0].Name
+	bcs[0].Spec.RunPolicy = obuildv1.BuildRunPolicySerial
+	bcs[0].Spec.Triggers = []obuildv1.BuildTriggerPolicy{
+		{
+			GitLabWebHook: &obuildv1.WebHookTrigger{
+				AllowEnv:        false,
+				SecretReference: &obuildv1.SecretLocalReference{Name: "dafsaf"},
+			},
+		},
+	}
+	bcs[1].Spec.Triggers = []obuildv1.BuildTriggerPolicy{
+		{
+			GitLabWebHook: &obuildv1.WebHookTrigger{
+				AllowEnv:        false,
+				SecretReference: &obuildv1.SecretLocalReference{Name: "eqwrer"},
+			},
+		},
+	}
+	assert.True(t, equalBuildConfigs(&bcs[0], &bcs[1]), "Expected resources to be deemed equal based on BC comparator")
 }

--- a/pkg/resource/compare/test/utils_test.go
+++ b/pkg/resource/compare/test/utils_test.go
@@ -22,3 +22,13 @@ func TestMapBuilder(t *testing.T) {
 	assert.Len(t, resMap[reflect.TypeOf(corev1.Service{})], 1, "Expect map to have 1 service")
 	assert.Len(t, resMap[reflect.TypeOf(oappsv1.DeploymentConfig{})], 1, "Expect map to have 1 deployment config")
 }
+
+func TestNilResources(t *testing.T) {
+	mapBuilder := compare.NewMapBuilder()
+	mapBuilder.Add(nil)
+	assert.Len(t, mapBuilder.ResourceMap(), 0, "Expect map to have zero entries")
+	dcPtr := &oappsv1.DeploymentConfig{}
+	dcPtr = nil
+	mapBuilder.Add(dcPtr)
+	assert.Len(t, mapBuilder.ResourceMap(), 0, "Expect map to have zero entries")
+}

--- a/pkg/resource/compare/utils.go
+++ b/pkg/resource/compare/utils.go
@@ -20,6 +20,12 @@ func (this *mapBuilder) ResourceMap() map[reflect.Type][]resource.KubernetesReso
 
 func (this *mapBuilder) Add(resources ...resource.KubernetesResource) *mapBuilder {
 	for index := range resources {
+		if resources[index] == nil {
+			logger.Info("Got nil")
+			continue
+		} else {
+			logger.Info("proceeding with ", "resources[index]", resources[index])
+		}
 		resourceType := reflect.ValueOf(resources[index]).Elem().Type()
 		this.resourceMap[resourceType] = append(this.resourceMap[resourceType], resources[index])
 	}

--- a/pkg/resource/compare/utils.go
+++ b/pkg/resource/compare/utils.go
@@ -20,11 +20,8 @@ func (this *mapBuilder) ResourceMap() map[reflect.Type][]resource.KubernetesReso
 
 func (this *mapBuilder) Add(resources ...resource.KubernetesResource) *mapBuilder {
 	for index := range resources {
-		if resources[index] == nil {
-			logger.Info("Got nil")
+		if resources[index] == nil || reflect.ValueOf(resources[index]).IsNil() {
 			continue
-		} else {
-			logger.Info("proceeding with ", "resources[index]", resources[index])
 		}
 		resourceType := reflect.ValueOf(resources[index]).Elem().Type()
 		this.resourceMap[resourceType] = append(this.resourceMap[resourceType], resources[index])

--- a/pkg/resource/test/utils.go
+++ b/pkg/resource/test/utils.go
@@ -3,6 +3,7 @@ package test
 import (
 	"fmt"
 	oappsv1 "github.com/openshift/api/apps/v1"
+	buildv1 "github.com/openshift/api/build/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,6 +52,16 @@ func GetDeploymentConfigs(count int) []oappsv1.DeploymentConfig {
 		}
 		dc.Name = fmt.Sprintf("%s%d", "dc", (i + 1))
 		slice = append(slice, dc)
+	}
+	return slice
+}
+
+func GetBuildConfigs(count int) []buildv1.BuildConfig {
+	var slice []buildv1.BuildConfig
+	for i := 0; i < count; i++ {
+		bc := buildv1.BuildConfig{}
+		bc.Name = fmt.Sprintf("%s%d", "bc", (i + 1))
+		slice = append(slice, bc)
 	}
 	return slice
 }

--- a/pkg/resource/test/utils.go
+++ b/pkg/resource/test/utils.go
@@ -42,7 +42,9 @@ func GetDeploymentConfigs(count int) []oappsv1.DeploymentConfig {
 		dc := oappsv1.DeploymentConfig{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{},
-			Spec:       oappsv1.DeploymentConfigSpec{},
+			Spec: oappsv1.DeploymentConfigSpec{
+				Template: &corev1.PodTemplateSpec{},
+			},
 			Status: oappsv1.DeploymentConfigStatus{
 				ReadyReplicas: 0,
 			},


### PR DESCRIPTION
When an ImageChange trigger is used, generated values are filled in on both the container image and the trigger itself that should be ignored

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>