### PR TITLE
Support reading kubernetes resource lists that hold resource item pointers in the array

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,12 +26,34 @@
   version = "v9"
 
 [[projects]]
+  digest = "1:f6944c59395c37a8c6fc9f65ba4e64dce4bf0eb9e459ed1ceb51d18a88efbc35"
+  name = "github.com/coreos/prometheus-operator"
+  packages = [
+    "pkg/apis/monitoring",
+    "pkg/apis/monitoring/v1",
+  ]
+  pruneopts = "UT"
+  revision = "908ee0372a9ac2c6574d589fdc56a4f3cb5f12d1"
+  version = "v0.33.0"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   pruneopts = "UT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
+
+[[projects]]
+  digest = "1:01d38d940d55f5e5fc41b5cfd2f204209222225c989d0f5876036cf869196d25"
+  name = "github.com/emicklei/go-restful"
+  packages = [
+    ".",
+    "log",
+  ]
+  pruneopts = "UT"
+  revision = "5d8b667fa26d374ff451368b5040d3adbb9c7db4"
+  version = "v2.11.0"
 
 [[projects]]
   digest = "1:ac425d784b13d49b37a5bbed3ce022677f8f3073b216f05d6adcb9303e27fa0f"
@@ -550,9 +572,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:22abb5d4204ab1a0dcc9cda64906a31c43965ff5159e8b9f766c9d2a162dbed5"
+  digest = "1:4c2cbfb5ec9dc5612f8fb1c32343304efe5388c11367361b95b95c00653843c9"
   name = "k8s.io/kube-openapi"
-  packages = ["pkg/util/proto"]
+  packages = [
+    "pkg/common",
+    "pkg/util/proto",
+  ]
   pruneopts = "UT"
   revision = "0270cf2f1c1d995d34b36019a6f65d58e6e33ad4"
 
@@ -593,6 +618,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1",
     "github.com/ghodss/yaml",
     "github.com/go-openapi/spec",
     "github.com/go-openapi/strfmt",

--- a/pkg/resource/read/reader.go
+++ b/pkg/resource/read/reader.go
@@ -44,12 +44,20 @@ func (this *resourceReader) List(listObject runtime.Object) ([]resource.Kubernet
 	}
 	itemsValue := reflect.Indirect(reflect.ValueOf(listObject)).FieldByName("Items")
 	for index := 0; index < itemsValue.Len(); index++ {
-		item := itemsValue.Index(index).Addr().Interface().(resource.KubernetesResource)
+		item := addr(itemsValue.Index(index)).Interface().(resource.KubernetesResource)
 		if this.ownerObject == nil || isOwner(this.ownerObject, item) {
 			resources = append(resources, item)
 		}
 	}
 	return resources, nil
+}
+
+func addr(v reflect.Value) reflect.Value {
+	if v.Kind() == reflect.Ptr {
+		return v
+	}
+
+	return v.Addr()
 }
 
 func isOwner(owner metav1.Object, res resource.KubernetesResource) bool {


### PR DESCRIPTION
Custom resource APIs of some operators use pointers of the items in the resource list, e.g. [Prometheus Operator](https://github.com/coreos/prometheus-operator/blob/29199d546e0bcb98b82f90b266eb437f1b1934c2/pkg/apis/monitoring/v1/types.go#L75).

Added a [function](https://github.com/RHsyseng/operator-utils/blob/647f170e356ba1e7ed956f6c11891a20b5849c19/pkg/resource/read/reader.go#L55) to check this case when reading this kind of resources.

```
type PrometheusList struct {
	metav1.TypeMeta `json:",inline"`
	// Standard list metadata
	// More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
	metav1.ListMeta `json:"metadata,omitempty"`
	// List of Prometheuses
	Items []*Prometheus `json:"items"`
}
```

```
type ServiceMonitorList struct {
	metav1.TypeMeta `json:",inline"`
	// Standard list metadata
	// More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
	metav1.ListMeta `json:"metadata,omitempty"`
	// List of ServiceMonitors
	Items []*ServiceMonitor `json:"items"`
}
```