### PR TITLE
add resource detector

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -588,10 +588,11 @@
   version = "kubernetes-1.13.1"
 
 [[projects]]
-  digest = "1:c859e94e84f47a74e98f61fe55ae164f10c38d32d87b6fd44b071664c8eceabc"
+  digest = "1:72ac015c3eff0c02a84a62b6cad29a8c826a73d14c2423d8fc8782c7169f5ba4"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
+    "discovery/fake",
     "dynamic",
     "kubernetes/scheme",
     "pkg/apis/clientauthentication",
@@ -686,7 +687,9 @@
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/version",
     "k8s.io/client-go/discovery",
+    "k8s.io/client-go/discovery/fake",
     "k8s.io/client-go/rest",
+    "k8s.io/client-go/testing",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
     "sigs.k8s.io/controller-runtime/pkg/client/fake",

--- a/pkg/resource/detector/README.md
+++ b/pkg/resource/detector/README.md
@@ -1,0 +1,53 @@
+### Example usage:
+
+Setting up the detector:
+```go
+    //you would most likely have this code in your main.go
+    dc, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
+    if err != nil {
+        panic("Could not create discovery client")
+    }
+
+    d, err := detector.NewAutoDetect(dc)
+    if err != nil {
+        panic("error creating autodetector: " + err.Error())
+    }
+
+    d.Start(5 * time.Second) //scan for new CRDs every 5 seconds
+```
+
+Triggering an action when a particular CRD shows up:
+```go
+    // and pass this detector instance to the `add` function of your operator's controller, where you could run:
+    d.AddCRDTrigger(&package.CRD{
+        TypeMeta: metav1.TypeMeta{
+            Kind:       package.CrdKind,
+            APIVersion: package.SchemeGroupVersion.String(),
+        },
+    }, func(crd runtime.Object) {
+        // Do actions now that the package.CRD exists in the API, e.g begin watching it:
+        c.Watch(&source.Kind{Type: &package.CRD{}}, &EnqueueForObject{})
+    })
+```
+
+Triggering an action when any of multiple CRDs show up:
+```go
+    // and pass this detector instance to the `add` function of your operator's controller, where you could run:
+    d.AddCRDsTrigger([]runtime.Object{
+        &package.CRD{
+            TypeMeta: metav1.TypeMeta{
+                Kind:       package.CrdKind,
+                APIVersion: package.SchemeGroupVersion.String(),
+            },
+        },
+        &package.OtherCrd{
+            TypeMeta: metav1.TypeMeta{
+                Kind: package.OtherCrdKind:
+                APIVersion: package.SchemeGroupVersion.String(),
+            },
+        },
+    }, func(crd runtime.Object) {
+        // Do actions now that the package.CRD exists in the API, e.g begin watching it:
+        c.Watch(&source.Kind{Type: crd}, &EnqueueForObject{})
+    })
+```

--- a/pkg/resource/detector/detector.go
+++ b/pkg/resource/detector/detector.go
@@ -1,0 +1,92 @@
+package detector
+
+import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
+	"time"
+)
+
+// Detector represents a procedure that runs in the background, periodically auto-detecting features
+type Detector struct {
+	dc     discovery.DiscoveryInterface
+	ticker *time.Ticker
+	crds   map[runtime.Object]trigger
+}
+
+type trigger func(runtime.Object)
+
+// New creates a new auto-detect runner
+func NewAutoDetect(dc discovery.DiscoveryInterface) (*Detector, error) {
+	return &Detector{dc: dc, crds: map[runtime.Object]trigger{}}, nil
+}
+
+//AddCRDTrigger to run the trigger function,
+//the first time that the background scanner discovers that the CRD type specified exists
+func (d *Detector) AddCRDTrigger(crd runtime.Object, trigger trigger) {
+	d.crds[crd] = trigger
+}
+
+//AddCRDsTrigger to run the trigger function,
+//the first time that the background scanner discovers that each of the CRD types specified exists
+func (d *Detector) AddCRDsTrigger(crds []runtime.Object, trigger trigger) {
+	for _, crd := range crds {
+		d.AddCRDTrigger(crd, trigger)
+	}
+}
+
+//AddCRDsWithTriggers to run the associated trigger function for the particular CRD,
+//the first time that the background scanner discovers that the CRD type specified exists
+func (d *Detector) AddCRDsWithTriggers(crdsTriggers map[runtime.Object]trigger) {
+	for crd, trigger := range crdsTriggers {
+		d.AddCRDTrigger(crd, trigger)
+	}
+}
+
+// Start initializes the auto-detection process that runs in the background
+func (d *Detector) Start(interval time.Duration) {
+	go func() {
+		d.autoDetectCapabilities()
+		d.ticker = time.NewTicker(interval)
+		for range d.ticker.C {
+			d.autoDetectCapabilities()
+		}
+	}()
+}
+
+// Stop causes the background process to stop auto detecting capabilities
+func (d *Detector) Stop() {
+	d.ticker.Stop()
+}
+
+func (d *Detector) autoDetectCapabilities() {
+	for crd, trigger := range d.crds {
+		crdGVK := crd.GetObjectKind().GroupVersionKind()
+		resourceExists, _ := d.resourceExists(d.dc, crdGVK.GroupVersion().String(), crdGVK.Kind)
+		if resourceExists {
+			stateManager := GetStateManager()
+			if stateManager.GetState(crdGVK.Kind) != true {
+				stateManager.SetState(crdGVK.Kind, true)
+				trigger(crd)
+			}
+		}
+	}
+}
+
+//copied from operator-sdk to avoid pulling in thousands of files in imports
+//https://github.com/operator-framework/operator-sdk/blob/92d78a2c25f0edbe039c4906a88fbb38c022018c/pkg/k8sutil/k8sutil.go#L93-L108
+func (d *Detector) resourceExists(dc discovery.DiscoveryInterface, apiGroupVersion, kind string) (bool, error) {
+	apiLists, err := dc.ServerResources()
+	if err != nil {
+		return false, err
+	}
+	for _, apiList := range apiLists {
+		if apiList.GroupVersion == apiGroupVersion {
+			for _, r := range apiList.APIResources {
+				if r.Kind == kind {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}

--- a/pkg/resource/detector/detector_test.go
+++ b/pkg/resource/detector/detector_test.go
@@ -1,0 +1,56 @@
+package detector
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	discoveryFake "k8s.io/client-go/discovery/fake"
+	k8sTesting "k8s.io/client-go/testing"
+	"testing"
+	"time"
+)
+
+func TestDetectorDetects(t *testing.T) {
+	crdDiscovered := false
+	dc := &discoveryFake.FakeDiscovery{
+		Fake:               &k8sTesting.Fake{},
+		FakedServerVersion: nil,
+	}
+
+	d, err := NewAutoDetect(dc)
+	if err != nil {
+		t.Fatalf("expected no errors, got: %s", err.Error())
+	}
+
+	// run very frequently, for faster tests
+	d.Start(1 * time.Nanosecond)
+	d.AddCRDTrigger(&appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "deployment",
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+		},
+	}, func(crd runtime.Object) {
+		crdDiscovered = true
+
+	})
+
+	//wait a few intervals
+	time.Sleep(2 * time.Millisecond)
+
+	if crdDiscovered {
+		t.Fatalf("CRD Discovered too early")
+	}
+
+	dc.Resources = []*metav1.APIResourceList{
+		&metav1.APIResourceList{
+			TypeMeta:     metav1.TypeMeta{},
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{{Kind: "deployment"}},
+		},
+	}
+
+	time.Sleep(2 * time.Millisecond)
+	if ! crdDiscovered {
+		t.Fatalf("CRD not discovered correctly")
+	}
+}

--- a/pkg/resource/detector/stateManager.go
+++ b/pkg/resource/detector/stateManager.go
@@ -1,0 +1,41 @@
+package detector
+
+import "sync"
+
+const (
+	RealmLabelSelectorsKey = "realmLabelSelectors"
+)
+
+type StateManager struct {
+	*sync.Mutex
+	state map[string]interface{}
+}
+
+var singleton *StateManager
+var once sync.Once
+
+func GetStateManager() *StateManager {
+	once.Do(func() {
+		singleton = &StateManager{Mutex: &sync.Mutex{}}
+		singleton.state = make(map[string]interface{})
+	})
+	return singleton
+}
+
+func (sm *StateManager) GetState(key string) interface{} {
+	sm.Lock()
+	defer sm.Unlock()
+	return sm.state[key]
+}
+
+func (sm *StateManager) SetState(key string, value interface{}) {
+	sm.Lock()
+	defer sm.Unlock()
+	sm.state[key] = value
+}
+
+func (sm *StateManager) Clear() {
+	sm.Lock()
+	defer sm.Unlock()
+	sm.state = make(map[string]interface{})
+}

--- a/pkg/resource/detector/stateManager_test.go
+++ b/pkg/resource/detector/stateManager_test.go
@@ -1,0 +1,24 @@
+package detector
+
+import (
+	"testing"
+)
+
+func TestStateManager_Test_(t *testing.T) {
+	stateManager := GetStateManager()
+	stateManagerTwo := GetStateManager()
+
+	stateManager.SetState("Test", "string")
+
+	if stateManager.GetState("NotSet") != nil {
+		t.Fatalf("Expected nil, got '%s'", stateManager.GetState("NotSet"))
+	}
+
+	if stateManager.GetState("Test") != "string" {
+		t.Fatalf("Expected 'string' got '%s'", stateManager.GetState("Test"))
+	}
+
+	if stateManager != stateManagerTwo {
+		t.Fatalf("Expected objects to be equal")
+	}
+}


### PR DESCRIPTION
Allow users to set up a background listener for when new CRDs are registered against the API, and trigger a function when they are detected.

For example, you may want to add Prometheus CRs for your product, if Prometheus is ever installed via an operator. This utility package makes it much more convenient to do things like that.

I've included a simple readme, to help understand what is happening in here.