### PR TITLE
Sorting EnvVars by Name before comparing

### DIFF
--- a/pkg/resource/test/utils.go
+++ b/pkg/resource/test/utils.go
@@ -100,3 +100,19 @@ func GetSecrets(count int) []corev1.Secret {
 	}
 	return slice
 }
+
+func GetEnvVars(count int, ordered bool) []corev1.EnvVar {
+	var slice []corev1.EnvVar
+	suffix := 0
+	for i := 0; i < count; i++ {
+		if ordered {
+			suffix = i + 1
+		} else {
+			suffix = count - i
+		}
+		env := corev1.EnvVar{Name: fmt.Sprintf("VAR%d", suffix), Value: fmt.Sprintf("value_%d", suffix)}
+		slice = append(slice, env)
+	}
+
+	return slice
+}


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

In this PR, we introduce a way to sort the `EnvVars` before comparing. In scenarios where the envs are the same, but in different order, the `Comparator` triggers an update to the resource, something that we might not want to happen, increasing the updating/reconciliation frequency.

Let me know if this is ok, so I can prepare a PR for the other branches as well.