### PR TITLE
Add Version Mapping as API

### DIFF
--- a/pkg/utils/openshift/utils.go
+++ b/pkg/utils/openshift/utils.go
@@ -43,8 +43,16 @@ Supported platform: OpenShift
 cfg : OpenShift platform config, use runtime config if nil is passed in.
 version: Supported version format : Major.Minor
 	       e.g.: 4.3
- */
+*/
 func CompareOpenShiftVersion(cfg *rest.Config, version string) (int, error) {
 	return platform.K8SBasedPlatformVersioner{}.CompareOpenShiftVersion(nil, cfg, version)
 }
 
+/*
+MapKnownVersion maps from K8S version of PlatformInfo to equivalent OpenShift version
+
+Result: OpenShiftVersion{ Version: 4.1.2 }
+*/
+func MapKnownVersion(info platform.PlatformInfo) platform.OpenShiftVersion {
+	return platform.MapKnownVersion(info)
+}

--- a/pkg/utils/openshift/utils_test.go
+++ b/pkg/utils/openshift/utils_test.go
@@ -36,6 +36,6 @@ func TestOpenShiftVersion_MapKnownVersion(t *testing.T) {
 	}
 
 	for _, v := range cases {
-		assert.Equal(t, v.expectedOCPVersion, platform.MapKnownVersion(v.info).Version, v.label+": expected OCP version to match")
+		assert.Equal(t, v.expectedOCPVersion, MapKnownVersion(v.info).Version, v.label+": expected OCP version to match")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Marco Yeung <myeung@redhat.com>

Apps are using the MapKnownVersion map directly. An API is now needed in the openshift pkg to provide backward compatibility.