### PR TITLE
Utility function to check CRD is available

### DIFF
--- a/internal/platform/platform_versioner.go
+++ b/internal/platform/platform_versioner.go
@@ -38,9 +38,13 @@ Result: OpenShiftVersion{ Version: 4.1.2 }
 func MapKnownVersion(info PlatformInfo) OpenShiftVersion {
 	k8sToOcpMap := map[string]string{
 		"1.10+": "3.10",
+		"1.10":  "3.10",
 		"1.11+": "3.11",
+		"1.11":  "3.11",
 		"1.13+": "4.1",
+		"1.13":  "4.1",
 		"1.14+": "4.2",
+		"1.14":  "4.2",
 		"1.16+": "4.3",
 		"1.16":  "4.3",
 	}

--- a/internal/platform/platform_versioner_test.go
+++ b/internal/platform/platform_versioner_test.go
@@ -142,7 +142,7 @@ func TestClientCallVersionComparsion(t *testing.T) {
 		label        string
 		discoverer   Discoverer
 		config       *rest.Config
-		expectedInfo  int
+		expectedInfo int
 		expectedErr  bool
 	}{
 		{

--- a/pkg/utils/kubernetes/utils.go
+++ b/pkg/utils/kubernetes/utils.go
@@ -4,31 +4,30 @@ import (
 	"errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-func CustomResourceDefinitionExists(gvk schema.GroupVersionKind) (bool, error) {
+func CustomResourceDefinitionExists(gvk schema.GroupVersionKind) error {
 	cfg, err := config.GetConfig()
 	if err != nil {
-		return false, err
+		return err
 	}
-	return customResourceDefinitionExists(gvk, cfg)
-}
-
-func customResourceDefinitionExists(gvk schema.GroupVersionKind, cfg *rest.Config) (bool, error) {
 	client, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
-		return false, err
+		return err
 	}
+	return customResourceDefinitionExists(gvk, client)
+}
+
+func customResourceDefinitionExists(gvk schema.GroupVersionKind, client discovery.ServerResourcesInterface) error {
 	api, err := client.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
 	if err != nil {
-		return false, err
+		return err
 	}
 	for _, a := range api.APIResources {
 		if a.Kind == gvk.Kind {
-			return true, nil
+			return nil
 		}
 	}
-	return false, errors.New(gvk.String() + " Kind not found ")
+	return errors.New(gvk.String() + " Kind not found ")
 }

--- a/pkg/utils/kubernetes/utils.go
+++ b/pkg/utils/kubernetes/utils.go
@@ -1,0 +1,34 @@
+package kubernetes
+
+import (
+	"errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func CustomResourceDefinitionExists(gvk schema.GroupVersionKind) (bool, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return false, err
+	}
+	return customResourceDefinitionExists(gvk, cfg)
+}
+
+func customResourceDefinitionExists(gvk schema.GroupVersionKind, cfg *rest.Config) (bool, error) {
+	client, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return false, err
+	}
+	api, err := client.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
+	if err != nil {
+		return false, err
+	}
+	for _, a := range api.APIResources {
+		if a.Kind == gvk.Kind {
+			return true, nil
+		}
+	}
+	return false, errors.New(gvk.String() + " Kind not found ")
+}

--- a/pkg/utils/kubernetes/utils_test.go
+++ b/pkg/utils/kubernetes/utils_test.go
@@ -1,0 +1,31 @@
+package kubernetes
+
+import (
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery/fake"
+	k8sTesting "k8s.io/client-go/testing"
+	"testing"
+)
+
+func TestCustomResourceDefinitionExists(t *testing.T) {
+	client := &fake.FakeDiscovery{
+		Fake:               &k8sTesting.Fake{},
+		FakedServerVersion: nil,
+	}
+	client.Resources = []*metav1.APIResourceList{
+		{
+			TypeMeta:     metav1.TypeMeta{},
+			GroupVersion: "console.openshift.io/v1",
+			APIResources: []metav1.APIResource{{Kind: "ConsoleYAMLSample"}},
+		},
+	}
+	gvk := schema.GroupVersionKind{Group: "console.openshift.io", Version: "v1", Kind: "ConsoleYAMLSample"}
+	err := customResourceDefinitionExists(gvk, client)
+	assert.Nil(t, err, "Failed to find ", gvk)
+
+	gvk = schema.GroupVersionKind{Group: "console.openshift.io", Version: "v2", Kind: "ConsoleYAMLSample"}
+	err = customResourceDefinitionExists(gvk, client)
+	assert.NotNil(t, err, "Did not expect to find ", gvk)
+}

--- a/pkg/utils/openshift/utils.go
+++ b/pkg/utils/openshift/utils.go
@@ -56,3 +56,4 @@ Result: OpenShiftVersion{ Version: 4.1.2 }
 func MapKnownVersion(info platform.PlatformInfo) platform.OpenShiftVersion {
 	return platform.MapKnownVersion(info)
 }
+

--- a/pkg/utils/openshift/utils.go
+++ b/pkg/utils/openshift/utils.go
@@ -56,4 +56,3 @@ Result: OpenShiftVersion{ Version: 4.1.2 }
 func MapKnownVersion(info platform.PlatformInfo) platform.OpenShiftVersion {
 	return platform.MapKnownVersion(info)
 }
-


### PR DESCRIPTION
- Function always returns an error when GVK is not found, so the boolean return type is redundant
- Added unit test based on k8s fake testing library, adjusted main function to take accordingly
    
Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>
