### PR TITLE
Rebase next into main and remove dependency from next branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,17 @@ This library layers on top of the Operator SDK, having set of utilities function
 
 In July of 2020, our team [moved away from using the term `master`](https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language) for our default branch. As a result, our branching scheme is as follows:
 
-- The [main](https://github.com/RHsyseng/operator-utils/tree/main) (default) branch currently supports **OCP 4.10** (K8S 1.23), the latest GA release.
-- The [next](https://github.com/RHsyseng/operator-utils/tree/next) branch currently supports **OCP 4.11** (K8S 1.24).
-- For versions of `operator-utils` targeting earlier releases of OCP (starting with 4.2), please refer to the [tags](https://github.com/RHsyseng/operator-utils/tags) section.
+- The [main](https://github.com/RHsyseng/operator-utils/tree/main) (default) branch supports **OCP 4.11** (K8S 1.24)
+- For versions of `operator-utils` targeting any release of OCP (starting with 4.2), please refer to the [tags](https://github.com/RHsyseng/operator-utils/tags) section.
   - tag `v1.X.Y` indicates support for OCP `vX.Y`
-- With each General Availability release of OCP, the `main` branch will be given a tag matching the previously supported OCP version in `main`, then the `next` branch will be rebased onto `main`.
+- With each General Availability release of OCP a new tag will be created from the `v1.X.Y.x` branch then the `main` branch will point to the latest OCP version.
 
 ## Contributing to the `operator-utils` Project
 
 All bugs, tasks, fixes or enhancements should be tracked as [GitHub Issues](https://github.com/RHsyseng/operator-utils/issues) & [Pull Requests](https://github.com/RHsyseng/operator-utils/pulls).
 
-- To contribute features targeting **OCP 4.10** only, use a local feature branch based off of & targeting `origin/main` with any PR's. Reference any JIRA/GitHub issues in PR's where applicable.
-- To contribute features targeting **OCP 4.11** only, use a local feature branch based off of & targeting `origin/next` with any PR's, Reference any JIRA/GitHub issues in PR's where applicable.
-- To contribute features targeting **both currently supported versions**, first complete the commit/PR work targeting `next`. Once that PR is merged to `next`, create a new PR with cherry-pick of the commit targeting `main`.
-- Contributions targeting OCP versions older than what's currently supported by `main` will typically no longer be accepted. Please contact contributors for further discussion.
+- To contribute features targeting **OCP 4.11** only, use a local feature branch based off of & targeting `origin/main` with any PR's, Reference any JIRA/GitHub issues in PR's where applicable.
+- To contribute features targeting **both currently supported versions**, first complete the commit/PR work targeting `main`. Once that PR is merged to `main`, create a new PR with cherry-pick of the commit targeting the branch of the specific OCP version that it should be backported to.
 
 ## Declaring operator-utils dependency
 

--- a/internal/platform/platform_versioner.go
+++ b/internal/platform/platform_versioner.go
@@ -63,6 +63,8 @@ func MapKnownVersion(info PlatformInfo) OpenShiftVersion {
 		"1.22":  "4.9",
 		"1.23+": "4.10",
 		"1.23":  "4.10",
+		"1.24+": "4.11",
+		"1.24":  "4.11",
 	}
 	return OpenShiftVersion{Version: k8sToOcpMap[info.K8SVersion]}
 }

--- a/internal/platform/platform_versioner_test.go
+++ b/internal/platform/platform_versioner_test.go
@@ -150,7 +150,7 @@ func TestClientCallVersionComparsion(t *testing.T) {
 			discoverer: FakeDiscoverer{
 				serverInfo: &version.Info{
 					Major: "1",
-					Minor: "23",
+					Minor: "24",
 				},
 				groupList: &v1.APIGroupList{
 					TypeMeta: v1.TypeMeta{},
@@ -166,7 +166,7 @@ func TestClientCallVersionComparsion(t *testing.T) {
 			discoverer: FakeDiscoverer{
 				serverInfo: &version.Info{
 					Major: "1",
-					Minor: "23+",
+					Minor: "24+",
 				},
 				groupList: &v1.APIGroupList{
 					TypeMeta: v1.TypeMeta{},
@@ -211,7 +211,7 @@ func TestClientCallVersionComparsion(t *testing.T) {
 		},
 	}
 
-	versionToTest := "4.10"
+	versionToTest := "4.11"
 	for _, tc := range testcases {
 		res, err := pv.CompareOpenShiftVersion(tc.discoverer, tc.config, versionToTest)
 		if tc.expectedErr {


### PR DESCRIPTION
After OCP 4.11 is GA the main branch must be updated

This is also a proposal to remove the dependency of the `next` branch and use a development-branch approach in order to have `main` branch with the `latest` OCP version.
That means that when a new OCP version is released a development branch `v1.X.Y.x` will be created (e.g. `v1.4.10.x`) so that contributions to latest can happen on `main` and backports to specific versions can be cherry-picked to the specific target version, allowing the possibility to create micro-releases e.g. `v1.4.10.1` for patches