### PR TITLE
[#110] Fix comparator logger init

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/apiextensions-apiserver v0.25.0 // indirect
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -925,6 +925,7 @@ k8s.io/api v0.23.0/go.mod h1:8wmDdLBHBNxtOIytwLstXt5E9PddnZb0GaMcqsvDBpg=
 k8s.io/api v0.25.4 h1:3YO8J4RtmG7elEgaWMb4HgmpS2CfY1QlaOz9nwB+ZSs=
 k8s.io/api v0.25.4/go.mod h1:IG2+RzyPQLllQxnhzD8KQNEu4c4YvyDTpSMztf4A0OQ=
 k8s.io/apiextensions-apiserver v0.25.0 h1:CJ9zlyXAbq0FIW8CD7HHyozCMBpDSiH7EdrSTCZcZFY=
+k8s.io/apiextensions-apiserver v0.25.0/go.mod h1:3pAjZiN4zw7R8aZC5gR0y3/vCkGlAjCazcg1me8iB/E=
 k8s.io/apimachinery v0.23.0/go.mod h1:fFCTTBKvKcwTPFzjlcxp91uPFZr+JA0FubU4fLzzFYc=
 k8s.io/apimachinery v0.25.4 h1:CtXsuaitMESSu339tfhVXhQrPET+EiWnIY1rcurKnAc=
 k8s.io/apimachinery v0.25.4/go.mod h1:jaF9C/iPNM1FuLl7Zuy5b9v+n35HGSh6AQ4HYRkCqwo=

--- a/pkg/resource/compare/defaults.go
+++ b/pkg/resource/compare/defaults.go
@@ -2,11 +2,11 @@ package compare
 
 import (
 	"fmt"
-	"github.com/RHsyseng/operator-utils/pkg/logs"
 	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sort"
 	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	oappsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
@@ -177,8 +177,8 @@ func equalDeploymentConfigs(deployed client.Object, requested client.Object) boo
 	pairs = append(pairs, [2]interface{}{dc1.Spec, dc2.Spec})
 	equal := EqualPairs(pairs)
 	if !equal {
-		if logs.IsDebugLevel() {
-			logger.Debugf("Resources are not equal", "deployed", deployed, "requested", requested)
+		if logger.GetSink().Enabled(1) {
+			logger.V(1).Info("Resources are not equal", "deployed", deployed, "requested", requested)
 		} else {
 			logger.Info("Resources are not equal. For more details set the Operator log level to DEBUG.")
 		}
@@ -242,7 +242,7 @@ func equalDeployment(deployed client.Object, requested client.Object) bool {
 	pairs = append(pairs, [2]interface{}{d1.Spec, d2.Spec})
 	equal := EqualPairs(pairs)
 	if !equal {
-		logger.Debugf("Resources are not equal", "deployed", deployed, "requested", requested)
+		logger.V(1).Info("Resources are not equal", "deployed", deployed, "requested", requested)
 	}
 	return equal
 }
@@ -435,8 +435,8 @@ func equalServices(deployed client.Object, requested client.Object) bool {
 	pairs = append(pairs, [2]interface{}{service1.Spec, service2.Spec})
 	equal := EqualPairs(pairs)
 	if !equal {
-		if logs.IsDebugLevel() {
-			logger.Debugf("Resources are not equal", "deployed", deployed, "requested", requested)
+		if logger.GetSink().Enabled(1) {
+			logger.V(1).Info("Resources are not equal", "deployed", deployed, "requested", requested)
 		} else {
 			logger.Info("Resources are not equal. For more details set the Operator log level to DEBUG.")
 		}
@@ -485,8 +485,8 @@ func equalRoutes(deployed client.Object, requested client.Object) bool {
 	pairs = append(pairs, [2]interface{}{route1.Spec, route2.Spec})
 	equal := EqualPairs(pairs)
 	if !equal {
-		if logs.IsDebugLevel() {
-			logger.Debugf("Resources are not equal", "deployed", deployed, "requested", requested)
+		if logger.GetSink().Enabled(1) {
+			logger.V(1).Info("Resources are not equal", "deployed", deployed, "requested", requested)
 		} else {
 			logger.Info("Resources are not equal. For more details set the Operator log level to DEBUG.")
 		}
@@ -505,8 +505,8 @@ func equalRoles(deployed client.Object, requested client.Object) bool {
 	pairs = append(pairs, [2]interface{}{role1.Rules, role2.Rules})
 	equal := EqualPairs(pairs)
 	if !equal {
-		if logs.IsDebugLevel() {
-			logger.Debugf("Resources are not equal", "deployed", deployed, "requested", requested)
+		if logger.GetSink().Enabled(1) {
+			logger.V(1).Info("Resources are not equal", "deployed", deployed, "requested", requested)
 		} else {
 			logger.Info("Resources are not equal. For more details set the Operator log level to DEBUG.")
 		}
@@ -524,8 +524,8 @@ func equalServiceAccounts(deployed client.Object, requested client.Object) bool 
 	pairs = append(pairs, [2]interface{}{sa1.Annotations, sa2.Annotations})
 	equal := EqualPairs(pairs)
 	if !equal {
-		if logs.IsDebugLevel() {
-			logger.Debugf("Resources are not equal", "deployed", deployed, "requested", requested)
+		if logger.GetSink().Enabled(1) {
+			logger.V(1).Info("Resources are not equal", "deployed", deployed, "requested", requested)
 		} else {
 			logger.Info("Resources are not equal. For more details set the Operator log level to DEBUG.")
 		}
@@ -545,8 +545,8 @@ func equalRoleBindings(deployed client.Object, requested client.Object) bool {
 	pairs = append(pairs, [2]interface{}{binding1.RoleRef.Name, binding2.RoleRef.Name})
 	equal := EqualPairs(pairs)
 	if !equal {
-		if logs.IsDebugLevel() {
-			logger.Debugf("Resources are not equal", "deployed", deployed, "requested", requested)
+		if logger.GetSink().Enabled(1) {
+			logger.V(1).Info("Resources are not equal", "deployed", deployed, "requested", requested)
 		} else {
 			logger.Info("Resources are not equal. For more details set the Operator log level to DEBUG.")
 		}
@@ -567,8 +567,8 @@ func equalSecrets(deployed client.Object, requested client.Object) bool {
 	pairs = append(pairs, [2]interface{}{secret1.Data, secret2.Data})
 	equal := EqualPairs(pairs)
 	if !equal {
-		if logs.IsDebugLevel() {
-			logger.Debugf("Resources are not equal", "deployed", deployed, "requested", requested)
+		if logger.GetSink().Enabled(1) {
+			logger.V(1).Info("Resources are not equal", "deployed", deployed, "requested", requested)
 		} else {
 			logger.Info("Resources are not equal. For more details set the Operator log level to DEBUG.")
 		}
@@ -644,8 +644,8 @@ func equalBuildConfigs(deployed client.Object, requested client.Object) bool {
 	pairs = append(pairs, [2]interface{}{bc1.Spec, bc2.Spec})
 	equal := EqualPairs(pairs)
 	if !equal {
-		if logs.IsDebugLevel() {
-			logger.Debugf("Resources are not equal", "deployed", deployed, "requested", requested)
+		if logger.GetSink().Enabled(1) {
+			logger.V(1).Info("Resources are not equal", "deployed", deployed, "requested", requested)
 		} else {
 			logger.Info("Resources are not equal. For more details set the Operator log level to DEBUG.")
 		}
@@ -676,8 +676,8 @@ func EqualPairs(objects [][2]interface{}) bool {
 func Equals(deployed interface{}, requested interface{}) bool {
 	equal := reflect.DeepEqual(deployed, requested)
 	if !equal {
-		if logs.IsDebugLevel() {
-			logger.Debugf("Objects are not equal", "deployed", deployed, "requested", requested)
+		if logger.GetSink().Enabled(1) {
+			logger.V(1).Info("Objects are not equal", "deployed", deployed, "requested", requested)
 		} else {
 			logger.Info("Objects are not equal. For more details set the Operator log level to DEBUG.")
 		}

--- a/pkg/resource/compare/map.go
+++ b/pkg/resource/compare/map.go
@@ -1,12 +1,13 @@
 package compare
 
 import (
-	"github.com/RHsyseng/operator-utils/pkg/logs"
 	"reflect"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var logger = logs.GetLogger("comparator")
+var logger = ctrl.Log.WithName("comparator")
 
 type MapComparator struct {
 	Comparator ResourceComparator


### PR DESCRIPTION
Replace `GetLogger` with `Log.WithName` because `GetLogger` set the controller runtime logger preventing operator to set their loggers.

This partially reverts 7a9086dae039b0dc22aaa8a64462f036bdc770a1