### PR TITLE
fix!: compare objects semantically equal using deep.Equal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-openapi/spec v0.19.9
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/go-openapi/validate v0.19.11
+	github.com/go-test/deep v1.1.0
 	github.com/google/gnostic v0.5.7-v3refs
 	github.com/openshift/api v0.0.0-20211209135129-c58d9f695577
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/go-openapi/validate v0.19.11/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
+github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
 github.com/gobuffalo/depgen v0.1.0/go.mod h1:+ifsuy7fhi15RWncXQQKjWS9JPkdah5sZvtHc2RXGlg=

--- a/pkg/resource/compare/defaults.go
+++ b/pkg/resource/compare/defaults.go
@@ -8,6 +8,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/go-test/deep"
 	oappsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -674,10 +675,11 @@ func EqualPairs(objects [][2]interface{}) bool {
 }
 
 func Equals(deployed interface{}, requested interface{}) bool {
-	equal := reflect.DeepEqual(deployed, requested)
+	diffs := deep.Equal(deployed, requested)
+	equal := len(diffs) == 0
 	if !equal {
 		if logger.GetSink().Enabled(1) {
-			logger.V(1).Info("Objects are not equal", "deployed", deployed, "requested", requested)
+			logger.V(1).Info("Objects are not equal", "deployed", deployed, "requested", requested, "diffs", diffs)
 		} else {
 			logger.Info("Objects are not equal. For more details set the Operator log level to DEBUG.")
 		}


### PR DESCRIPTION
Fix #109 

Introduce the use of the [go-test/deep](https://github.com/go-test/deep) library which allows semantic equality and more granularity for tracing the differences of two objects.